### PR TITLE
💚 fix: authenticate with GitHub Packages in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      packages: read
       pages: write
       id-token: write
     environment:
@@ -25,8 +27,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Add packages:read permission and configure registry-url with NODE_AUTH_TOKEN so npm ci can install the private
@paulvantuyl/pro-regular-svg-icons package.